### PR TITLE
Create and assign a Virtual Circuit to multiple VLANs in a single API request

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,7 @@ You might also have to manually run the database migrations for Netbox to create
 python3 manage.py migrate
 ```
 
-For more information about installing plugins, refer to [NetBox's
-documentation
-](https://netbox.readthedocs.io/en/stable/plugins/).
+For more information about installing plugins, refer to [NetBox's documentation.](https://netbox.readthedocs.io/en/stable/plugins/)
 
 ## Using
 

--- a/netbox_virtual_circuit_plugin/api/serializers.py
+++ b/netbox_virtual_circuit_plugin/api/serializers.py
@@ -3,25 +3,25 @@ from netbox_virtual_circuit_plugin.models import VirtualCircuit, VirtualCircuitV
 
 
 class VLANSerializer(ModelSerializer):
-    id = SerializerMethodField('get_id')
-    vid = SerializerMethodField('get_vid')
 
     class Meta:
         model = VirtualCircuitVLAN
-        fields = ['id', 'vid']
-
-    def get_id(self, obj):
-        return obj.vlan.id
-
-    def get_vid(self, obj):
-        return obj.vlan.vid
+        fields = ['vlan']
 
 class VirtualCircuitSerializer(ModelSerializer):
-    vlans = VLANSerializer(many=True, read_only=True)
+    vlans = VLANSerializer(many=True)
 
     class Meta:
         model = VirtualCircuit
         fields = ['vcid', 'name', 'status', 'context', 'vlans']
+
+    def create(self, validated_data):
+        vlans_data = validated_data.pop('vlans')
+        virtual_circuit = VirtualCircuit.objects.create(**validated_data)
+        for vlan in vlans_data:
+            VirtualCircuitVLAN.objects.create(virtual_circuit=virtual_circuit, **vlan)
+        return virtual_circuit
+
 
 class VirtualCircuitVLANSerializer(ModelSerializer):
 


### PR DESCRIPTION
Follow up from #9, this PRs allows user to create a Virtual Circuit and assign it to multiple VLANs in a single API request at `/api/plugins/virtual-circuit/virtual-circuits/`. That said, a `vlans` field must be provided in the `POST` request body, where its value is a list of vlan objects (`vlan` is the key and its primary key is the value).

**To demonstrate that better, below is an example using `curl`.**

First, verify that no virtual circuit or no vlan assignment is made by issuing`GET` requests to list all the virtual circuits and assigned vlans.
```sh
➜  ~ curl -X GET -H "Authorization: Token REDACTED" -H "Content-Type: application/json" -H "Accept: application/json; indent=4" http://localhost:8000/api/plugins/virtual-circuit/virtual-circuits/
{
    "count": 0,
    "next": null,
    "previous": null,
    "results": []
}% 
```
```sh                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
➜  ~ curl -X GET -H "Authorization: Token REDACTED" -H "Content-Type: application/json" -H "Accept: application/json; indent=4" http://localhost:8000/api/plugins/virtual-circuit/vlans/
{
    "count": 0,
    "next": null,
    "previous": null,
    "results": []
}% 
```

Create a Virtual Circuit with ID 1000, name "foo", and assign it to VLANS 1 and 2 using a `POST` request.
```sh
➜  ~ curl -X POST -H "Authorization: Token REDACTED" -H "Content-Type: application/json" -H "Accept: application/json; indent=4" http://localhost:8000/api/plugins/virtual-circuit/virtual-circuits/ --data '{"vcid": 1000, "name": "foo", "vlans": [{"vlan": 1}, {"vlan": 2}]}'
{
    "vcid": 1000,
    "name": "foo",
    "status": "pending-configuration",
    "context": "",
    "vlans": [
        {
            "vlan": 1
        },
        {
            "vlan": 2
        }
    ]
}% 
```

Since the request above is sucessful, issue `GET` requests to list all virtual circuits and assigned VLANs again. We can now see that the virtual circuit is successfully created with 2 VLANs assigned to it. 
```sh
➜  ~ curl -X GET -H "Authorization: Token REDACTED" -H "Content-Type: application/json" -H "Accept: application/json; indent=4" http://localhost:8000/api/plugins/virtual-circuit/virtual-circuits/                                             
{
    "count": 1,
    "next": null,
    "previous": null,
    "results": [
        {
            "vcid": 1000,
            "name": "foo",
            "status": "pending-configuration",
            "context": "",
            "vlans": [
                {
                    "vlan": 1
                },
                {
                    "vlan": 2
                }
            ]
        }
    ]
}%
```
```sh
➜  ~ curl -X GET -H "Authorization: Token REDACTED" -H "Content-Type: application/json" -H "Accept: application/json; indent=4" http://localhost:8000/api/plugins/virtual-circuit/vlans/                                                        
{
    "count": 2,
    "next": null,
    "previous": null,
    "results": [
        {
            "id": 2,
            "virtual_circuit": 1000,
            "vlan": 2
        },
        {
            "id": 1,
            "virtual_circuit": 1000,
            "vlan": 1
        }
    ]
}% 
```