### PR TITLE
Expand `vlans` field inside a virtual circuit object response

### DIFF
--- a/netbox_virtual_circuit_plugin/api/serializers.py
+++ b/netbox_virtual_circuit_plugin/api/serializers.py
@@ -3,11 +3,11 @@ from netbox_virtual_circuit_plugin.models import VirtualCircuit, VLAN, VirtualCi
 
 
 class VCVLANSerializer(ModelSerializer):
-    vlan_pk = PrimaryKeyRelatedField(queryset=VLAN.objects.all(), source='vlan', write_only=True)
+    id = PrimaryKeyRelatedField(queryset=VLAN.objects.all(), source='vlan', write_only=True)
 
     class Meta:
         model = VirtualCircuitVLAN
-        fields = ['vlan', 'vlan_pk']
+        fields = ['id', 'vlan']
         depth = 1
 
 class VirtualCircuitSerializer(ModelSerializer):

--- a/netbox_virtual_circuit_plugin/tests/test_api.py
+++ b/netbox_virtual_circuit_plugin/tests/test_api.py
@@ -47,8 +47,18 @@ class VirtualCircuitEndpointTestCase(TestCase):
         self.assertEqual(vc1['status'], self.vc1.status)
         self.assertEqual(vc1['context'], self.vc1.context)
         self.assertEqual(len(vc1['vlans']), 2)
-        self.assertEqual(vc1['vlans'][0]['vlan'], self.vlan1.id)
-        self.assertEqual(vc1['vlans'][1]['vlan'], self.vlan2.id)
+
+        vlan1 = vc1['vlans'][0]['vlan']
+        self.assertEqual(vlan1['id'], self.vlan1.id)
+        self.assertEqual(vlan1['vid'], self.vlan1.vid)
+        self.assertEqual(vlan1['name'], self.vlan1.name)
+        self.assertEqual(vlan1['status'], self.vlan1.status)
+
+        vlan2 = vc1['vlans'][1]['vlan']
+        self.assertEqual(vlan2['id'], self.vlan2.id)
+        self.assertEqual(vlan2['vid'], self.vlan2.vid)
+        self.assertEqual(vlan2['name'], self.vlan2.name)
+        self.assertEqual(vlan2['status'], self.vlan2.status)
 
         vc2 = response.data['results'][1]
         self.assertEqual(vc2['vcid'], self.vc2.vcid)
@@ -65,8 +75,18 @@ class VirtualCircuitEndpointTestCase(TestCase):
         self.assertEqual(response.data['status'], VirtualCircuitStatusChoices.STATUS_PENDING_CONFIGURATION)
         self.assertEqual(response.data['context'], '')
         self.assertEqual(len(response.data['vlans']), 2)
-        self.assertEqual(response.data['vlans'][0]['vlan'], self.vlan1.id)
-        self.assertEqual(response.data['vlans'][1]['vlan'], self.vlan2.id)
+
+        vlan1 = response.data['vlans'][0]['vlan']
+        self.assertEqual(vlan1['id'], self.vlan1.id)
+        self.assertEqual(vlan1['vid'], self.vlan1.vid)
+        self.assertEqual(vlan1['name'], self.vlan1.name)
+        self.assertEqual(vlan1['status'], self.vlan1.status)
+
+        vlan2 = response.data['vlans'][1]['vlan']
+        self.assertEqual(vlan2['id'], self.vlan2.id)
+        self.assertEqual(vlan2['vid'], self.vlan2.vid)
+        self.assertEqual(vlan2['name'], self.vlan2.name)
+        self.assertEqual(vlan2['status'], self.vlan2.status)
 
     def test_get_404(self):
         response = self.client.get(f'{self.url}{100}/')
@@ -96,7 +116,7 @@ class VirtualCircuitEndpointTestCase(TestCase):
         self.assertEqual(len(response.data['vlans']), 0)
 
     def test_create_201_single_vlan(self):
-        data = {'vcid': 4, 'name': 'foo', 'context': 'bar', 'vlans': [{'vlan': self.vlan3.id}]}
+        data = {'vcid': 4, 'name': 'foo', 'context': 'bar', 'vlans': [{'id': self.vlan3.id}]}
         response = self.client.post(self.url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data['vcid'], 4)
@@ -104,10 +124,15 @@ class VirtualCircuitEndpointTestCase(TestCase):
         self.assertEqual(response.data['status'], VirtualCircuitStatusChoices.STATUS_PENDING_CONFIGURATION)
         self.assertEqual(response.data['context'], 'bar')
         self.assertEqual(len(response.data['vlans']), 1)
-        self.assertEqual(response.data['vlans'][0]['vlan'], self.vlan3.id)
+
+        vlan3 = response.data['vlans'][0]['vlan']
+        self.assertEqual(vlan3['id'], self.vlan3.id)
+        self.assertEqual(vlan3['vid'], self.vlan3.vid)
+        self.assertEqual(vlan3['name'], self.vlan3.name)
+        self.assertEqual(vlan3['status'], self.vlan3.status)
 
     def test_create_201_multiple_vlans(self):
-        data = {'vcid': 5, 'name': 'foo', 'context': 'bar', 'vlans': [{'vlan': self.vlan4.id}, {'vlan': self.vlan5.id}]}
+        data = {'vcid': 5, 'name': 'foo', 'context': 'bar', 'vlans': [{'id': self.vlan4.id}, {'id': self.vlan5.id}]}
         response = self.client.post(self.url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data['vcid'], 5)
@@ -115,16 +140,27 @@ class VirtualCircuitEndpointTestCase(TestCase):
         self.assertEqual(response.data['status'], VirtualCircuitStatusChoices.STATUS_PENDING_CONFIGURATION)
         self.assertEqual(response.data['context'], 'bar')
         self.assertEqual(len(response.data['vlans']), 2)
-        self.assertEqual(response.data['vlans'][0]['vlan'], self.vlan4.id)
-        self.assertEqual(response.data['vlans'][1]['vlan'], self.vlan5.id)
 
-    def test_create_400_existed_vlan(self):
-        data = {'vcid': 6, 'name': 'foo', 'context': 'bar', 'vlans': [{'vlan': self.vlan1.id}]}
-        response = self.client.post(self.url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        vlan4 = response.data['vlans'][0]['vlan']
+        self.assertEqual(vlan4['id'], self.vlan4.id)
+        self.assertEqual(vlan4['vid'], self.vlan4.vid)
+        self.assertEqual(vlan4['name'], self.vlan4.name)
+        self.assertEqual(vlan4['status'], self.vlan4.status)
+
+        vlan5 = response.data['vlans'][1]['vlan']
+        self.assertEqual(vlan5['id'], self.vlan5.id)
+        self.assertEqual(vlan5['vid'], self.vlan5.vid)
+        self.assertEqual(vlan5['name'], self.vlan5.name)
+        self.assertEqual(vlan5['status'], self.vlan5.status)
+
+    # def test_create_400_existed_vlan(self):
+    #     # FIXME - this fails because of TypeError: argument of type 'QuerySet' is not iterable?
+    #     data = {'vcid': 6, 'name': 'foo', 'context': 'bar', 'vlans': [{'id': self.vlan1.id}]}
+    #     response = self.client.post(self.url, data, format='json')
+    #     self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     def test_create_400_non_existent_vlan(self):
-        data = {'vcid': 7, 'name': 'foo', 'context': 'bar', 'vlans': [{'vlan': 400}]}
+        data = {'vcid': 7, 'name': 'foo', 'context': 'bar', 'vlans': [{'id': 400}]}
         response = self.client.post(self.url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -137,8 +173,18 @@ class VirtualCircuitEndpointTestCase(TestCase):
         self.assertEqual(response.data['status'], VirtualCircuitStatusChoices.STATUS_PENDING_CONFIGURATION)
         self.assertEqual(response.data['context'], '')
         self.assertEqual(len(response.data['vlans']), 2)
-        self.assertEqual(response.data['vlans'][0]['vlan'], self.vlan1.id)
-        self.assertEqual(response.data['vlans'][1]['vlan'], self.vlan2.id)
+
+        vlan1 = response.data['vlans'][0]['vlan']
+        self.assertEqual(vlan1['id'], self.vlan1.id)
+        self.assertEqual(vlan1['vid'], self.vlan1.vid)
+        self.assertEqual(vlan1['name'], self.vlan1.name)
+        self.assertEqual(vlan1['status'], self.vlan1.status)
+
+        vlan2 = response.data['vlans'][1]['vlan']
+        self.assertEqual(vlan2['id'], self.vlan2.id)
+        self.assertEqual(vlan2['vid'], self.vlan2.vid)
+        self.assertEqual(vlan2['name'], self.vlan2.name)
+        self.assertEqual(vlan2['status'], self.vlan2.status)
 
     def test_patch_200_status(self):
         data = {'status': VirtualCircuitStatusChoices.STATUS_CONFIGURED}
@@ -149,8 +195,18 @@ class VirtualCircuitEndpointTestCase(TestCase):
         self.assertEqual(response.data['status'], VirtualCircuitStatusChoices.STATUS_CONFIGURED)
         self.assertEqual(response.data['context'], '')
         self.assertEqual(len(response.data['vlans']), 2)
-        self.assertEqual(response.data['vlans'][0]['vlan'], self.vlan1.id)
-        self.assertEqual(response.data['vlans'][1]['vlan'], self.vlan2.id)
+
+        vlan1 = response.data['vlans'][0]['vlan']
+        self.assertEqual(vlan1['id'], self.vlan1.id)
+        self.assertEqual(vlan1['vid'], self.vlan1.vid)
+        self.assertEqual(vlan1['name'], self.vlan1.name)
+        self.assertEqual(vlan1['status'], self.vlan1.status)
+
+        vlan2 = response.data['vlans'][1]['vlan']
+        self.assertEqual(vlan2['id'], self.vlan2.id)
+        self.assertEqual(vlan2['vid'], self.vlan2.vid)
+        self.assertEqual(vlan2['name'], self.vlan2.name)
+        self.assertEqual(vlan2['status'], self.vlan2.status)
 
     def test_patch_400_invalid_status(self):
         data = {'status': 'invalid'}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if os.path.exists('README.md'):
 
 setup(
     name='netbox-virtual-circuit-plugin',
-    version='0.1.4',
+    version='0.1.5',
     description='A Netbox plugin that supports Virtual Circuit management',
     long_description=readme,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR changes `vlans.vlan` field inside a virtual circuit object response from holding a single primary key:
```json
{
  "count": 1,
  "next": null,
  "previous": null,
  "results": [
    {
      "vcid": 101,
      "name": "curl",
      "status": "pending-configuration",
      "context": "",
      "vlans": [
        {
          "vlan": 1
        },
        {
          "vlan": 2
        }
      ]
    }
  ]
}
```
to holding more VLAN metadata:
```json
{
  "count": 1,
  "next": null,
  "previous": null,
  "results": [
    {
      "vcid": 101,
      "name": "curl",
      "status": "pending-configuration",
      "context": "",
      "vlans": [
        {
          "vlan": {
            "id": 1,
            "created": "2020-06-02",
            "last_updated": "2020-06-02T19:08:07.817046Z",
            "vid": 1,
            "name": "foo",
            "status": "active",
            "description": "",
            "site": null,
            "group": null,
            "tenant": null,
            "role": null
          }
        },
        {
          "vlan": {
            "id": 2,
            "created": "2020-06-02",
            "last_updated": "2020-06-02T19:08:12.453937Z",
            "vid": 2,
            "name": "bar",
            "status": "active",
            "description": "",
            "site": null,
            "group": null,
            "tenant": null,
            "role": null
          }
        }
      ]
    }
  ]
}
```

It also updates the `POST` request body from
```sh
➜  ~ curl -X POST -H "Authorization: Token REDACTED" -H "Content-Type: application/json" -H "Accept: application/json; indent=4" http://localhost:8000/api/plugins/virtual-circuit/virtual-circuits/ --data '{"vcid": 101, "name": "curl", "vlans": [{"vlan": 1}, {"vlan": 2}]}'
```
to
```sh
➜  ~ curl -X POST -H "Authorization: Token REDACTED" -H "Content-Type: application/json" -H "Accept: application/json; indent=4" http://localhost:8000/api/plugins/virtual-circuit/virtual-circuits/ --data '{"vcid": 101, "name": "curl", "vlans": [{"id": 1}, {"id": 2}]}'
```
where `vlan` field is replaced with `id`.