### PR TITLE
Fix swagger missing id

### DIFF
--- a/netbox_virtual_circuit_plugin/api/serializers.py
+++ b/netbox_virtual_circuit_plugin/api/serializers.py
@@ -2,32 +2,23 @@ from rest_framework.serializers import ModelSerializer, SerializerMethodField, P
 from netbox_virtual_circuit_plugin.models import VirtualCircuit, VLAN, VirtualCircuitVLAN
 
 
-class VCVLANSerializer(ModelSerializer):
-    id = PrimaryKeyRelatedField(queryset=VLAN.objects.all(), source='vlan', write_only=True)
+class NestedVCVLANSerializer(ModelSerializer):
 
     class Meta:
         model = VirtualCircuitVLAN
         fields = ['id', 'vlan']
-        depth = 1
 
 class VirtualCircuitSerializer(ModelSerializer):
-    vlans = VCVLANSerializer(many=True)
+    vlans = NestedVCVLANSerializer(many=True)
 
     class Meta:
         model = VirtualCircuit
         fields = ['vcid', 'name', 'status', 'context', 'vlans']
 
     def create(self, validated_data):
-        vlans = validated_data.pop('vlans')
+        vlans_data = validated_data.pop('vlans')
         virtual_circuit = VirtualCircuit.objects.create(**validated_data)
-        for vlan in vlans:
-            try:
-              ret = VirtualCircuitVLAN.objects.get(vlan=vlan.get('vlan'))
-              if ret:
-                  raise ValidationError({'id': f'VLAN {ret.vlan} is already assigned to Virtual Circuit {ret.virtual_circuit}'})
-            except VirtualCircuitVLAN.DoesNotExist:
-                pass
-
+        for vlan in vlans_data:
             VirtualCircuitVLAN.objects.create(virtual_circuit=virtual_circuit, **vlan)
         return virtual_circuit
 

--- a/netbox_virtual_circuit_plugin/tests/test_api.py
+++ b/netbox_virtual_circuit_plugin/tests/test_api.py
@@ -48,17 +48,13 @@ class VirtualCircuitEndpointTestCase(TestCase):
         self.assertEqual(vc1['context'], self.vc1.context)
         self.assertEqual(len(vc1['vlans']), 2)
 
-        vlan1 = vc1['vlans'][0]['vlan']
-        self.assertEqual(vlan1['id'], self.vlan1.id)
-        self.assertEqual(vlan1['vid'], self.vlan1.vid)
-        self.assertEqual(vlan1['name'], self.vlan1.name)
-        self.assertEqual(vlan1['status'], self.vlan1.status)
+        vlan1 = vc1['vlans'][0]
+        self.assertEqual(vlan1['id'], self.vc1_vlan1.id)
+        self.assertEqual(vlan1['vlan'], self.vlan1.id)
 
-        vlan2 = vc1['vlans'][1]['vlan']
-        self.assertEqual(vlan2['id'], self.vlan2.id)
-        self.assertEqual(vlan2['vid'], self.vlan2.vid)
-        self.assertEqual(vlan2['name'], self.vlan2.name)
-        self.assertEqual(vlan2['status'], self.vlan2.status)
+        vlan2 = vc1['vlans'][1]
+        self.assertEqual(vlan2['id'], self.vc1_vlan2.id)
+        self.assertEqual(vlan2['vlan'], self.vlan2.id)
 
         vc2 = response.data['results'][1]
         self.assertEqual(vc2['vcid'], self.vc2.vcid)
@@ -76,17 +72,13 @@ class VirtualCircuitEndpointTestCase(TestCase):
         self.assertEqual(response.data['context'], '')
         self.assertEqual(len(response.data['vlans']), 2)
 
-        vlan1 = response.data['vlans'][0]['vlan']
-        self.assertEqual(vlan1['id'], self.vlan1.id)
-        self.assertEqual(vlan1['vid'], self.vlan1.vid)
-        self.assertEqual(vlan1['name'], self.vlan1.name)
-        self.assertEqual(vlan1['status'], self.vlan1.status)
+        vlan1 = response.data['vlans'][0]
+        self.assertEqual(vlan1['id'], self.vc1_vlan1.id)
+        self.assertEqual(vlan1['vlan'], self.vlan1.id)
 
-        vlan2 = response.data['vlans'][1]['vlan']
-        self.assertEqual(vlan2['id'], self.vlan2.id)
-        self.assertEqual(vlan2['vid'], self.vlan2.vid)
-        self.assertEqual(vlan2['name'], self.vlan2.name)
-        self.assertEqual(vlan2['status'], self.vlan2.status)
+        vlan2 = response.data['vlans'][1]
+        self.assertEqual(vlan2['id'], self.vc1_vlan2.id)
+        self.assertEqual(vlan2['vlan'], self.vlan2.id)
 
     def test_get_404(self):
         response = self.client.get(f'{self.url}{100}/')
@@ -116,7 +108,7 @@ class VirtualCircuitEndpointTestCase(TestCase):
         self.assertEqual(len(response.data['vlans']), 0)
 
     def test_create_201_single_vlan(self):
-        data = {'vcid': 4, 'name': 'foo', 'context': 'bar', 'vlans': [{'id': self.vlan3.id}]}
+        data = {'vcid': 4, 'name': 'foo', 'context': 'bar', 'vlans': [{'vlan': self.vlan3.id}]}
         response = self.client.post(self.url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data['vcid'], 4)
@@ -125,14 +117,12 @@ class VirtualCircuitEndpointTestCase(TestCase):
         self.assertEqual(response.data['context'], 'bar')
         self.assertEqual(len(response.data['vlans']), 1)
 
-        vlan3 = response.data['vlans'][0]['vlan']
-        self.assertEqual(vlan3['id'], self.vlan3.id)
-        self.assertEqual(vlan3['vid'], self.vlan3.vid)
-        self.assertEqual(vlan3['name'], self.vlan3.name)
-        self.assertEqual(vlan3['status'], self.vlan3.status)
+        vlan3 = response.data['vlans'][0]
+        self.assertIn('id', vlan3)
+        self.assertEqual(vlan3['vlan'], self.vlan3.id)
 
     def test_create_201_multiple_vlans(self):
-        data = {'vcid': 5, 'name': 'foo', 'context': 'bar', 'vlans': [{'id': self.vlan4.id}, {'id': self.vlan5.id}]}
+        data = {'vcid': 5, 'name': 'foo', 'context': 'bar', 'vlans': [{'vlan': self.vlan4.id}, {'vlan': self.vlan5.id}]}
         response = self.client.post(self.url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data['vcid'], 5)
@@ -141,25 +131,21 @@ class VirtualCircuitEndpointTestCase(TestCase):
         self.assertEqual(response.data['context'], 'bar')
         self.assertEqual(len(response.data['vlans']), 2)
 
-        vlan4 = response.data['vlans'][0]['vlan']
-        self.assertEqual(vlan4['id'], self.vlan4.id)
-        self.assertEqual(vlan4['vid'], self.vlan4.vid)
-        self.assertEqual(vlan4['name'], self.vlan4.name)
-        self.assertEqual(vlan4['status'], self.vlan4.status)
+        vlan4 = response.data['vlans'][0]
+        self.assertIn('id', vlan4)
+        self.assertEqual(vlan4['vlan'], self.vlan4.id)
 
-        vlan5 = response.data['vlans'][1]['vlan']
-        self.assertEqual(vlan5['id'], self.vlan5.id)
-        self.assertEqual(vlan5['vid'], self.vlan5.vid)
-        self.assertEqual(vlan5['name'], self.vlan5.name)
-        self.assertEqual(vlan5['status'], self.vlan5.status)
+        vlan5 = response.data['vlans'][1]
+        self.assertIn('id', vlan5)
+        self.assertEqual(vlan5['vlan'], self.vlan5.id)
 
     def test_create_400_existed_vlan(self):
-        data = {'vcid': 6, 'name': 'foo', 'context': 'bar', 'vlans': [{'id': self.vlan1.id}]}
+        data = {'vcid': 6, 'name': 'foo', 'context': 'bar', 'vlans': [{'vlan': self.vlan1.id}]}
         response = self.client.post(self.url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_400_non_existent_vlan(self):
-        data = {'vcid': 7, 'name': 'foo', 'context': 'bar', 'vlans': [{'id': 400}]}
+        data = {'vcid': 7, 'name': 'foo', 'context': 'bar', 'vlans': [{'vlan': 400}]}
         response = self.client.post(self.url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -173,18 +159,6 @@ class VirtualCircuitEndpointTestCase(TestCase):
         self.assertEqual(response.data['context'], '')
         self.assertEqual(len(response.data['vlans']), 2)
 
-        vlan1 = response.data['vlans'][0]['vlan']
-        self.assertEqual(vlan1['id'], self.vlan1.id)
-        self.assertEqual(vlan1['vid'], self.vlan1.vid)
-        self.assertEqual(vlan1['name'], self.vlan1.name)
-        self.assertEqual(vlan1['status'], self.vlan1.status)
-
-        vlan2 = response.data['vlans'][1]['vlan']
-        self.assertEqual(vlan2['id'], self.vlan2.id)
-        self.assertEqual(vlan2['vid'], self.vlan2.vid)
-        self.assertEqual(vlan2['name'], self.vlan2.name)
-        self.assertEqual(vlan2['status'], self.vlan2.status)
-
     def test_patch_200_status(self):
         data = {'status': VirtualCircuitStatusChoices.STATUS_CONFIGURED}
         response = self.client.patch(f'{self.url}{self.vc1.vcid}/', data, format='json')
@@ -194,18 +168,6 @@ class VirtualCircuitEndpointTestCase(TestCase):
         self.assertEqual(response.data['status'], VirtualCircuitStatusChoices.STATUS_CONFIGURED)
         self.assertEqual(response.data['context'], '')
         self.assertEqual(len(response.data['vlans']), 2)
-
-        vlan1 = response.data['vlans'][0]['vlan']
-        self.assertEqual(vlan1['id'], self.vlan1.id)
-        self.assertEqual(vlan1['vid'], self.vlan1.vid)
-        self.assertEqual(vlan1['name'], self.vlan1.name)
-        self.assertEqual(vlan1['status'], self.vlan1.status)
-
-        vlan2 = response.data['vlans'][1]['vlan']
-        self.assertEqual(vlan2['id'], self.vlan2.id)
-        self.assertEqual(vlan2['vid'], self.vlan2.vid)
-        self.assertEqual(vlan2['name'], self.vlan2.name)
-        self.assertEqual(vlan2['status'], self.vlan2.status)
 
     def test_patch_400_invalid_status(self):
         data = {'status': 'invalid'}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if os.path.exists('README.md'):
 
 setup(
     name='netbox-virtual-circuit-plugin',
-    version='0.3.1',
+    version='1.0.0',
     description='A Netbox plugin that supports Virtual Circuit management',
     long_description=readme,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Follow up from #34, we realize that the missing `id` is the unique identifier of Virtual-Circuit-to-VLAN (VCVLAN) connections.  The previous implementation overrode `id` to return the nested VLAN objects and hence broke the Swagger specs. This PR fixes the issue by reserving that `id` key and use `vlan` key for querying VLAN objects instead.

This PR also removes the `depth` level so that only VLAN id and VCVLAN connection id will be returned - for a couple of reasons:
- [As we've seen, network-api doesn't consume these nested VLAN data](https://github.com/vapor-ware/network-api/pull/73).
- Leaving these out simplify the model a whole lot. Also, having the depth pinned at level 1 is not super helpful anyway.
- I'm afraid using `depth` here might not be the best way to do it actually.

So now, the response instead of looking like this: 
```sh
{
  "count": 1,
  "next": null,
  "previous": null,
  "results": [
    {
      "vcid": 101,
      "name": "curl",
      "status": "pending-configuration",
      "context": "",
      "vlans": [
        {
          "vlan": {
            "id": 1,
            "created": "2020-06-02",
            "last_updated": "2020-06-02T19:08:07.817046Z",
            "vid": 1,
            "name": "foo",
            "status": "active",
            "description": "",
            "site": null,
            "group": null,
            "tenant": null,
            "role": null
          }
        },
        {
          "vlan": {
            "id": 2,
            "created": "2020-06-02",
            "last_updated": "2020-06-02T19:08:12.453937Z",
            "vid": 2,
            "name": "bar",
            "status": "active",
            "description": "",
            "site": null,
            "group": null,
            "tenant": null,
            "role": null
          }
        }
      ]
    }
  ]
}
```
will look like this:
```sh
{
  "count": 1,
  "next": null,
  "previous": null,
  "results": [
    {
      "vcid": 101,
      "name": "curl",
      "status": "pending-configuration",
      "context": "",
      "vlans": [
        {
          "id": 1,
          "vlan": 1
        },
        {
          "id": 2,
          "vlan": 2
        }
      ]
    }
  ]
}
```

The POST body for creating a Virtual Circuit with VLANs data instead of looking like this:
```sh
➜  ~ curl -X POST -H "Authorization: Token REDACTED" -H "Content-Type: application/json" -H "Accept: application/json; indent=4" http://localhost:8000/api/plugins/virtual-circuit/virtual-circuits/ --data '{"vcid": 101, "name": "curl", "vlans": [{"id": 1}, {"id": 2}]}'
```
will look like this:
```sh
➜  ~ curl -X POST -H "Authorization: Token REDACTED" -H "Content-Type: application/json" -H "Accept: application/json; indent=4" http://localhost:8000/api/plugins/virtual-circuit/virtual-circuits/ --data '{"vcid": 101, "name": "curl", "vlans": [{"vlan": 1}, {"vlan": 2}]}'
```
where `vlan` is used instead of reserved `id` key.