### PR TITLE
feat: include created and last_updated timestamp in the api's response

### DIFF
--- a/netbox_virtual_circuit_plugin/api/serializers.py
+++ b/netbox_virtual_circuit_plugin/api/serializers.py
@@ -13,7 +13,7 @@ class VirtualCircuitSerializer(ModelSerializer):
 
     class Meta:
         model = VirtualCircuit
-        fields = ['vcid', 'name', 'status', 'context', 'vlans']
+        fields = ['vcid', 'name', 'status', 'context', 'vlans', 'created', 'last_updated']
 
     def create(self, validated_data):
         vlans_data = validated_data.pop('vlans')

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if os.path.exists('README.md'):
 
 setup(
     name='netbox-virtual-circuit-plugin',
-    version='1.4.0',
+    version='1.4.1',
     description='A Netbox plugin that supports Virtual Circuit management',
     long_description=readme,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if os.path.exists('README.md'):
 
 setup(
     name='netbox-virtual-circuit-plugin',
-    version='1.4.1',
+    version='1.4.0',
     description='A Netbox plugin that supports Virtual Circuit management',
     long_description=readme,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR adds `created` date field and `last_updated` timestamp field to the API's response of the `/api/plugins/virtual-circuit/virtual-circuits/` endpoint. The response now looks something like:
```
{
  "count": 1,
  "next": null,
  "previous": null,
  "results": [
    {
      "vcid": 100,
      "name": "foo",
      "status": "pending-configuration",
      "context": "",
      "vlans": [
        {
          "id": 1000,
          "vlan": 1000
        }
      ],
      "created": "2020-12-07",
      "last_updated": "2020-12-07T21:53:42.912419Z"
    }
  ]
}
```

It also bumps the version to `1.4.1`.