### PR TITLE
Plugin release for netbox v2.11.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ For more information about installing plugins, refer to [NetBox's documentation.
 
 Below is a table describing the compatibility of various NetBox versions with NetBox Virtual Circuit Plugin versions.
 
-|                   | Netbox 2.8 | NetBox 2.9 | Netbox 2.10 |
-| ----------------- | ---------- | ---------- | ----------- |
-| `1.0.x`           | ✓          | ✗          | ✗           |
-| `1.1.x` to `1.5.x`| ✗          | ✓          | ✗           |
-| `1.6.x` and above | ✗          | ✗          | ✓           |
+|                   | Netbox 2.8 | NetBox 2.9 | Netbox 2.10 | Netbox 2.11 |
+| ----------------- | ---------- | ---------- | ----------- | ----------- |
+| `1.0.x`           | ✓          | ✗          | ✗           | x           |
+| `1.1.x` to `1.5.x`| ✗          | ✓          | ✗           | x           |
+| `1.6.x` and above | ✗          | ✗          | ✓           | x           |
+| `1.7.x` and above | ✗          | ✗          | x           | ✓           |
 
 ## Using
 

--- a/netbox_virtual_circuit_plugin/filters.py
+++ b/netbox_virtual_circuit_plugin/filters.py
@@ -1,12 +1,10 @@
 import django_filters
 from django.db.models import Q
 
-from utilities.filters import NameSlugSearchFilterSet
-
 from .models import VirtualCircuit
 
 
-class VirtualCircuitFilter(NameSlugSearchFilterSet):
+class VirtualCircuitFilter(django_filters.FilterSet):
     q = django_filters.CharFilter(
         method="search",
         label="Search",
@@ -15,6 +13,7 @@ class VirtualCircuitFilter(NameSlugSearchFilterSet):
     class Meta:
         model = VirtualCircuit
         fields = [
+            'vcid',
             'status',
             'context',
             'description',

--- a/netbox_virtual_circuit_plugin/models.py
+++ b/netbox_virtual_circuit_plugin/models.py
@@ -2,12 +2,12 @@ from django.db import models
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.urls import reverse
 from ipam.models import VLAN
-from extras.models import ChangeLoggedModel
+from netbox.models import ChangeLoggingMixin
 
 from .choices import VirtualCircuitStatusChoices
 
 
-class VirtualCircuit(ChangeLoggedModel):
+class VirtualCircuit(ChangeLoggingMixin):
     """Virtual Circuit model."""
 
     vcid = models.BigIntegerField(
@@ -46,7 +46,8 @@ class VirtualCircuit(ChangeLoggedModel):
     def get_absolute_url(self):
         return reverse('plugins:netbox_virtual_circuit_plugin:virtual_circuit', args=[self.vcid])
 
-class VirtualCircuitVLAN(ChangeLoggedModel):
+
+class VirtualCircuitVLAN(ChangeLoggingMixin):
     """Virtual Circuit to VLAN relationship."""
 
     virtual_circuit = models.ForeignKey(

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if os.path.exists('README.md'):
 
 setup(
     name='netbox-virtual-circuit-plugin',
-    version='1.6.2',
+    version='1.7.0',
     description='A Netbox plugin that supports Virtual Circuit management',
     long_description=readme,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR supports the plugin for netbox v2.11.x releases.
This PR didnt modify any model or api responses.User can access  this plugin once it will be releases with 1.7.0 tag .